### PR TITLE
Fixed typo with building base endpoint address

### DIFF
--- a/DSoft.Portable.WebClient.Rest.Encryption/RestServiceSecureClientBase.cs
+++ b/DSoft.Portable.WebClient.Rest.Encryption/RestServiceSecureClientBase.cs
@@ -29,7 +29,7 @@ namespace DSoft.Portable.WebClient.Rest.Encryption
         /// Gets the size of the key.
         /// </summary>
         /// <value>The size of the key.</value>
-        public KeySize KeySize => ((SecureRestClientOptions)Options).KeySize;
+        public KeySize KeySize => ((SecureRestApiClientOptions)Options).KeySize;
 
 
         #endregion
@@ -41,7 +41,7 @@ namespace DSoft.Portable.WebClient.Rest.Encryption
         /// </summary>
         /// <param name="options">The options.</param>
         /// <param name="initVectorProvider">The initialize vector provider.</param>
-        protected RestServiceSecureClientBase(IOptions<SecureRestClientOptions> options, IIVKeyProvider initVectorProvider) : this(options.Value, initVectorProvider)
+        protected RestServiceSecureClientBase(IOptions<SecureRestApiClientOptions> options, IIVKeyProvider initVectorProvider) : this(options.Value, initVectorProvider)
         {
             _initVectorProvider = initVectorProvider;
         }
@@ -51,7 +51,7 @@ namespace DSoft.Portable.WebClient.Rest.Encryption
         /// </summary>
         /// <param name="options">The options.</param>
         /// <param name="initVectorProvider">The initialize vector provider.</param>
-        protected RestServiceSecureClientBase(SecureRestClientOptions options, IIVKeyProvider initVectorProvider) : base(options)
+        protected RestServiceSecureClientBase(SecureRestApiClientOptions options, IIVKeyProvider initVectorProvider) : base(options)
         {
             _initVectorProvider = initVectorProvider;
         }

--- a/DSoft.Portable.WebClient.Rest.Encryption/SecureRestApiClientOptions.cs
+++ b/DSoft.Portable.WebClient.Rest.Encryption/SecureRestApiClientOptions.cs
@@ -8,7 +8,7 @@ namespace DSoft.Portable.WebClient.Rest.Encryption
     /// <summary>
     /// Security Options for the rest client
     /// </summary>
-    public class SecureRestClientOptions : RestApiClientOptions
+    public class SecureRestApiClientOptions : RestApiClientOptions
     {
         /// <summary>
         /// Gets or sets the size of the key for the encryption

--- a/DSoft.Portable.WebClient.Rest.Encryption/SecureRestClientOptions.cs
+++ b/DSoft.Portable.WebClient.Rest.Encryption/SecureRestClientOptions.cs
@@ -8,7 +8,7 @@ namespace DSoft.Portable.WebClient.Rest.Encryption
     /// <summary>
     /// Security Options for the rest client
     /// </summary>
-    public class SecureRestClientOptions : RestClientOptions
+    public class SecureRestClientOptions : RestApiClientOptions
     {
         /// <summary>
         /// Gets or sets the size of the key for the encryption

--- a/DSoft.Portable.WebClient.Rest/RestApiClientOptions.cs
+++ b/DSoft.Portable.WebClient.Rest/RestApiClientOptions.cs
@@ -9,7 +9,7 @@ namespace DSoft.Portable.WebClient.Rest
     /// <summary>
     /// Options for the rest client
     /// </summary>
-    public class RestClientOptions
+    public class RestApiClientOptions
     {
         /// <summary>
         /// Gets the base URL.

--- a/DSoft.Portable.WebClient.Rest/RestServiceClientBase.cs
+++ b/DSoft.Portable.WebClient.Rest/RestServiceClientBase.cs
@@ -19,7 +19,7 @@ namespace DSoft.Portable.WebClient.Rest
 	public abstract class RestServiceClientBase
 	{
 		#region Fields
-		private readonly RestClientOptions _options;
+		private readonly RestApiClientOptions _options;
         #endregion
 
         #region Properties
@@ -28,7 +28,7 @@ namespace DSoft.Portable.WebClient.Rest
         /// Gets the options provided to the client
         /// </summary>
         /// <value>The options.</value>
-        public RestClientOptions Options => _options;
+        public RestApiClientOptions Options => _options;
 
         /// <summary>
         /// Gets the client version no.
@@ -141,7 +141,7 @@ namespace DSoft.Portable.WebClient.Rest
         /// Initializes a new instance of the <see cref="RestServiceClientBase"/> class.
         /// </summary>
         /// <param name="options">The options.</param>
-        protected RestServiceClientBase(IOptions<RestClientOptions> options) : this(options.Value)
+        protected RestServiceClientBase(IOptions<RestApiClientOptions> options) : this(options.Value)
         {
 				
         }
@@ -150,7 +150,7 @@ namespace DSoft.Portable.WebClient.Rest
         /// Initializes a new instance of the <see cref="RestServiceClientBase"/> class.
         /// </summary>
         /// <param name="options">The options.</param>
-        protected RestServiceClientBase(RestClientOptions options)
+        protected RestServiceClientBase(RestApiClientOptions options)
         {
             _options = options;
         }

--- a/DSoft.Portable.WebClient.Rest/RestServiceClientBase.cs
+++ b/DSoft.Portable.WebClient.Rest/RestServiceClientBase.cs
@@ -168,18 +168,18 @@ namespace DSoft.Portable.WebClient.Rest
         /// <returns></returns>
         public string CalculateUrlForMethod(string methodName, string parameterString = null, string controllerOverride = null)
 		{
-			var apiPrefix = ApiPrefix;
+			var apiPrefixBase = ApiPrefix;
 
-			if (!string.IsNullOrEmpty(apiPrefix) && !apiPrefix.EndsWith(@"/"))
+			if (!string.IsNullOrEmpty(apiPrefixBase) && !apiPrefixBase.EndsWith(@"/"))
 			{
-				apiPrefix = $"{apiPrefix}/";
+                apiPrefixBase = $"{apiPrefixBase}/";
 			}
 
-            var baseEndpointService = ApiPrefix;
+            var baseEndpointService = apiPrefixBase;
 
             if (!string.IsNullOrWhiteSpace(ServiceName))
             {
-                baseEndpointService = $"{apiPrefix}/{ServiceName}/";
+                baseEndpointService = $"{apiPrefixBase}/{ServiceName}/";
             }
 
             var controllerComponent = ControllerName;

--- a/TestHarness/MainViewModel.cs
+++ b/TestHarness/MainViewModel.cs
@@ -49,7 +49,7 @@ namespace TestHarness
 
 						var ivProvider = IVProviderFactory.Create(iVProviderOptions);
 
-                        SecureRestClientOptions options = new()
+                        SecureRestApiClientOptions options = new()
 						{
 							KeySize = KeySize.TwoFiftySix,
 						};

--- a/TestHarness/Services/SessionService.cs
+++ b/TestHarness/Services/SessionService.cs
@@ -16,7 +16,7 @@ namespace TestHarness.Services
 		protected override string ControllerName => "Session";
 
 
-		public SessionService(SecureRestClientOptions options, IIVKeyProvider initVectorProvider) : base(options, initVectorProvider)
+		public SessionService(SecureRestApiClientOptions options, IIVKeyProvider initVectorProvider) : base(options, initVectorProvider)
         {
 
 		}


### PR DESCRIPTION
Renamed RestClientOptons to RestApiClentOptions to avoid collision with RestSharp

Renamed securerestclientoptions to SecureRestApiClientOptions